### PR TITLE
Longer `jenkins.test.timeout`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,16 @@
                     </loggers>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- TODO at least locally, live tests are running extremely slowly: -->
+                        <jenkins.test.timeout>600</jenkins.test.timeout>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 466.892 s - in io.jenkins.plugins.pipeline_cloudwatch_logs.PipelineBridgeTest
```

:roll_eyes: 