### PR TITLE
Increase test timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <!-- TODO at least locally, live tests are running extremely slowly: -->
-                        <jenkins.test.timeout>600</jenkins.test.timeout>
+                        <!-- TODO locally and on CI, live tests are extremely slow: -->
+                        <jenkins.test.timeout>1200</jenkins.test.timeout>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
#81, #82, and #83 timed out `PipelineBridgeTest` in private CI. Test timeout is for the whole class in this case, and 10m is really not enough: 
![PipelineBridgeTest](https://github.com/jenkinsci/pipeline-cloudwatch-logs-plugin/assets/154109/0f2281bb-286f-4e45-ab8d-17055997cc8a)
