### PR TITLE
When loading logs, take the job start and end time into account.

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipeline_cloudwatch_logs/CloudWatchRetriever.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_cloudwatch_logs/CloudWatchRetriever.java
@@ -65,16 +65,23 @@ class CloudWatchRetriever {
 
     private static final Logger LOGGER = Logger.getLogger(CloudWatchRetriever.class.getName());
 
+    /** Buffer added before/after the build window to account for clock skew between Jenkins and CloudWatch. */
+    static final long CLOCK_SKEW_BUFFER_MS = 5 * 60 * 1000L; // 5 minutes
+
     private final String logStreamNameBase;
     private final String buildId;
     private final TimestampTracker timestampTracker;
     private final String logGroupName;
     private final CloudWatchLogsClient client;
+    private final long buildStartTime;
+    private final long buildEndTime;
 
-    CloudWatchRetriever(String logStreamNameBase, String buildId, TimestampTracker timestampTracker) throws IOException {
+    CloudWatchRetriever(String logStreamNameBase, String buildId, TimestampTracker timestampTracker, long buildStartTime, long buildEndTime) throws IOException {
         this.logStreamNameBase = logStreamNameBase;
         this.buildId = buildId;
         this.timestampTracker = timestampTracker;
+        this.buildStartTime = buildStartTime;
+        this.buildEndTime = buildEndTime;
         CloudWatchAwsGlobalConfiguration configuration = ExtensionList.lookupSingleton(CloudWatchAwsGlobalConfiguration.class);
         logGroupName = configuration.getLogGroupName();
         if (logGroupName == null) {
@@ -233,9 +240,16 @@ class CloudWatchRetriever {
     }
 
     private FilterLogEventsRequest.Builder createFilter() {
-        return FilterLogEventsRequest.builder().
+        FilterLogEventsRequest.Builder builder = FilterLogEventsRequest.builder().
             logGroupName(logGroupName).
             logStreamNamePrefix(logStreamNameBase + "@");
+        if (buildStartTime > 0) {
+            builder = builder.startTime(buildStartTime - CLOCK_SKEW_BUFFER_MS);
+        }
+        if (buildEndTime > 0) {
+            builder = builder.endTime(buildEndTime + CLOCK_SKEW_BUFFER_MS);
+        }
+        return builder;
     }
 
 }

--- a/src/main/java/io/jenkins/plugins/pipeline_cloudwatch_logs/PipelineBridge.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_cloudwatch_logs/PipelineBridge.java
@@ -119,7 +119,17 @@ public final class PipelineBridge implements LogStorageFactory {
         @Override
         public AnnotatedLargeText<FlowExecutionOwner.Executable> overallLog(FlowExecutionOwner.Executable build, boolean complete) {
             try {
-                return new CloudWatchRetriever(logStreamNameBase, buildId, timestampTracker()).overallLog(build, complete);
+                long buildStartTime = 0;
+                long buildEndTime = 0;
+                if (build instanceof Run) {
+                    Run<?, ?> run = (Run<?, ?>) build;
+                    buildStartTime = run.getStartTimeInMillis();
+                    long duration = run.getDuration();
+                    if (duration > 0) {
+                        buildEndTime = buildStartTime + duration;
+                    }
+                }
+                return new CloudWatchRetriever(logStreamNameBase, buildId, timestampTracker(), buildStartTime, buildEndTime).overallLog(build, complete);
             } catch (Exception x) {
                 return new BrokenLogStorage(x).overallLog(build, complete);
             }
@@ -128,7 +138,22 @@ public final class PipelineBridge implements LogStorageFactory {
         @Override
         public AnnotatedLargeText<FlowNode> stepLog(FlowNode node, boolean complete) {
             try {
-                return new CloudWatchRetriever(logStreamNameBase, buildId, timestampTracker()).stepLog(node, complete);
+                long buildStartTime = 0;
+                long buildEndTime = 0;
+                try {
+                    Queue.Executable exec = node.getExecution().getOwner().getExecutable();
+                    if (exec instanceof Run) {
+                        Run<?, ?> run = (Run<?, ?>) exec;
+                        buildStartTime = run.getStartTimeInMillis();
+                        long duration = run.getDuration();
+                        if (duration > 0) {
+                            buildEndTime = buildStartTime + duration;
+                        }
+                    }
+                } catch (IOException e) {
+                    LOGGER.log(Level.FINE, "Could not determine build time bounds for step log filter", e);
+                }
+                return new CloudWatchRetriever(logStreamNameBase, buildId, timestampTracker(), buildStartTime, buildEndTime).stepLog(node, complete);
             } catch (Exception x) {
                 return new BrokenLogStorage(x).stepLog(node, complete);
             }


### PR DESCRIPTION
With any quantity of logs spanning hundreds of builds in cloudwatch, the filter-log-events API call takes longer and longer to filter based on build number. As such, this PR limits the log retrieval to the timeframe of the job/build in question +- a "reasonable" buffer for clock skew.

### Testing done

Unit tests, then plugin built and used in a Jenkins environment with hundreds of cloudwatch logs streams. One filter query that this plugin used to execute took 7 minutes and 48 seconds to execute via AWS CLI, and would just time out in the Jenkins webpage. With this change, it loads in about 2 seconds (roughly).

One other change to the environment done before the code change was to add an indexed field on "build" to the cloudwatch log group.


### Submitter checklist
- [ X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ]X Link to relevant pull requests, esp. upstream and downstream changes
- [ X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
